### PR TITLE
FEAT: Create the 'create' page HTML (FNW-69)

### DIFF
--- a/react-frontend/src/pages/App/App.tsx
+++ b/react-frontend/src/pages/App/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Login from "../Login/login";
 import Signup from '../Signup/signup';
 import Explore from '../Explore/explore';
+import CreatePage from '../Create/create';
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
           <Route path="login" element={<Login />} />
           <Route path="signup" element={<Signup />} />
           <Route path="explore" element={<Explore />} />
+          <Route path="create" element={<CreatePage />} />
           {/* <Route path="*" element={<NoPage />} /> TODO: Error 404 */}
       </Routes>
     </BrowserRouter>

--- a/react-frontend/src/pages/Create/create.tsx
+++ b/react-frontend/src/pages/Create/create.tsx
@@ -1,0 +1,25 @@
+import Navbar from "../../components/Navbar/navbar";
+
+function CreatePage() {
+  return (
+    <div>
+        {/* <Navbar></Navbar> TODO: Decomment this when CSS of the page done*/}
+        <h1>Create a plum</h1>
+        <select name="pets" id="pet-select">
+            <option value="">--Action--</option>
+            <option value="test">Test</option>
+        </select>
+        <input type='area' className="bg-customYellow"></input>
+        <select name="pets" id="pet-select">
+            <option value="">--Reaction--</option>
+            <option value="test">Test</option>
+        </select>
+        <input type='area' className="bg-customYellow"></input>
+
+        <button type="button" className="bg-customGreen" >Create</button>
+
+    </div>
+    );
+}
+
+export default CreatePage;


### PR DESCRIPTION
This pull request introduces a new `CreatePage` component to the `react-frontend` application. The most important changes include importing and adding the `CreatePage` component to the router and defining the `CreatePage` component itself.

Changes to routing:

* [`react-frontend/src/pages/App/App.tsx`](diffhunk://#diff-ab17fd47ad9f1232b48efdddd567a8b1eb9e26ba72759bb586df04e2a3bf93cdR6): Imported `CreatePage` and added a new route for the `CreatePage` component. [[1]](diffhunk://#diff-ab17fd47ad9f1232b48efdddd567a8b1eb9e26ba72759bb586df04e2a3bf93cdR6) [[2]](diffhunk://#diff-ab17fd47ad9f1232b48efdddd567a8b1eb9e26ba72759bb586df04e2a3bf93cdR16)

New component definition:

* [`react-frontend/src/pages/Create/create.tsx`](diffhunk://#diff-e558ab923957e688b31c547bdc2e8b3c3952e587402f3d246fb7418e1d5d4884R1-R25): Defined the `CreatePage` component with a basic form structure, including a title, select elements, input fields, and a button.