### PR TITLE
FEAT: Create some test for the account api

### DIFF
--- a/express-backend/package-lock.json
+++ b/express-backend/package-lock.json
@@ -2562,6 +2562,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
       "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
+      "license": "MIT",
       "dependencies": {
         "methods": "^1.1.2",
         "superagent": "^9.0.1"

--- a/express-backend/tests/index.test.ts
+++ b/express-backend/tests/index.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { generateToken} from '../routes/account';
+import { describe, it, expect, vi } from 'vitest';
+import { generateToken } from '../routes/account';
 import request from 'supertest';
 import app from '../index';
+import prisma from '../prismaClient';
 
 describe('main test', () => {
     it('should pass', () => {
@@ -17,4 +18,84 @@ it('Should generate token', () => {
 it("Should return 200", async () => {
     const response = await request(app).get('/');
     expect(response.status).toBe(200);
+});
+
+describe('GET /triggers/templates', () => {
+    it('Should return 200 and a list of trigger templates', async () => {
+        const response = await request(app).get('/triggers/templates');
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body)).toBe(true);
+    });
+});
+
+describe('POST /account/register', () => {
+    it('Should register a new user and return 201 with a token', async () => {
+        const originalFindUnique = prisma.user.findUnique;
+        prisma.user.findUnique = vi.fn().mockResolvedValue(null);
+
+        const response = await request(app)
+            .post('/account/register')
+            .send({ mail: 'tests@tests.testsss', password: 'tests' });
+        expect(response.status).toBe(201);
+        expect(response.body.token).not.toBe(null);
+
+        prisma.user.findUnique = originalFindUnique;
+        prisma.user.delete = vi.fn().mockResolvedValue(null);
+    });
+
+    it('Should return 400 if mail or password is missing', async () => {
+        const response = await request(app)
+            .post('/account/register')
+            .send({ mail: 'test@example.com' });
+        expect(response.status).toBe(400);
+        expect(response.body.msg).toBe('Bad parameters');
+    });
+
+    it('Should return 409 if user already exists', async () => {
+        const originalFindUnique = prisma.user.findUnique;
+        prisma.user.findUnique = vi.fn().mockResolvedValue({ mail: 'test@tester.com' });
+
+        const response = await request(app)
+            .post('/account/register')
+            .send({ mail: 'test@tester.com', password: 'tester' });
+        expect(response.status).toBe(409);
+        expect(response.body.msg).toBe('User exists.');
+
+        prisma.user.findUnique = originalFindUnique;
+    });
+});
+
+describe('POST /account/login', () => {
+    it('Should login a user and return 200 with a token', async () => {
+        const originalFindUnique = prisma.user.findUnique;
+
+        const response = await request(app)
+            .post('/account/login')
+            .send({ mail: "mama@gmail.com", password: "ok" });
+        expect(response.status).toBe(200);
+        expect(response.body.token).not.toBe(null);
+
+        prisma.user.findUnique = originalFindUnique;
+    });
+
+    it('Should return 400 if mail or password is missing', async () => {
+        const response = await request(app)
+            .post('/account/login')
+            .send({ mail: 'test@example.com' });
+        expect(response.status).toBe(400);
+        expect(response.body.msg).toBe('Bad parameters');
+    });
+
+    it('Should return 409 if credentials are invalid', async () => {
+        const originalFindUnique = prisma.user.findUnique;
+        prisma.user.findUnique = vi.fn().mockResolvedValue(null);
+
+        const response = await request(app)
+            .post('/account/login')
+            .send({ mail: 'test@example.com', password: 'password123' });
+        expect(response.status).toBe(409);
+        expect(response.body.msg).toBe('Invalid Credentials');
+
+        prisma.user.findUnique = originalFindUnique;
+    });
 });


### PR DESCRIPTION
This pull request includes several updates to the `express-backend` project, primarily focusing on expanding test coverage and updating dependencies. The most important changes include adding new test cases for various endpoints and updating the `package-lock.json` file to include licensing information.

### Test coverage improvements:

* [`express-backend/tests/index.test.ts`](diffhunk://#diff-54aeedcdc520972f30ba9fab1e58b0a7128e3f88f36344394d99529cbaaf1cfbR22-R101): Added new test cases for `GET /triggers/templates`, `POST /account/register`, and `POST /account/login` endpoints. These tests cover scenarios such as successful requests, missing parameters, and handling of existing users or invalid credentials.
* [`express-backend/tests/index.test.ts`](diffhunk://#diff-54aeedcdc520972f30ba9fab1e58b0a7128e3f88f36344394d99529cbaaf1cfbL1-R5): Imported `prisma` and `vi` from `vitest` to mock database interactions and facilitate the new test cases.

### Dependency updates:

* [`express-backend/package-lock.json`](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR2565): Added the `license` field to the `supertest` dependency entry to include licensing information.