### PR TITLE
FEAT: actions & triggers allow to sort by provider (FNW-85)

### DIFF
--- a/express-backend/package-lock.json
+++ b/express-backend/package-lock.json
@@ -912,7 +912,7 @@
       "version": "22.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
       "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -1054,6 +1054,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -1101,7 +1102,8 @@
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -1150,6 +1152,7 @@
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -1190,6 +1193,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1288,6 +1292,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -1299,6 +1304,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1307,6 +1313,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1314,7 +1321,8 @@
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "dev": true
     },
     "node_modules/cookiejar": {
       "version": "2.1.4",
@@ -1353,6 +1361,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1394,6 +1403,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1402,6 +1412,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -1462,12 +1473,14 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1536,7 +1549,8 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1559,6 +1573,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1575,6 +1590,7 @@
       "version": "4.21.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
       "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -1622,6 +1638,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "dev": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -1686,6 +1703,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1694,6 +1712,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1838,6 +1857,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -1853,6 +1873,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -1880,6 +1901,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -2037,6 +2059,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2045,6 +2068,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -2061,6 +2085,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -2102,7 +2127,8 @@
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
@@ -2125,6 +2151,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2152,6 +2179,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -2167,17 +2195,11 @@
         "wrappy": "1"
       }
     },
-    "node_modules/openapi-types": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2194,7 +2216,8 @@
     "node_modules/path-to-regexp": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "dev": true
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -2265,6 +2288,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -2297,6 +2321,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2305,6 +2330,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -2356,6 +2382,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2374,7 +2401,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -2392,6 +2420,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
       "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "dev": true,
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -2415,6 +2444,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2422,12 +2452,14 @@
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "dev": true,
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
@@ -2457,7 +2489,8 @@
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
     },
     "node_modules/side-channel": {
       "version": "1.0.6",
@@ -2498,6 +2531,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2665,6 +2699,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -2717,6 +2752,7 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -2743,12 +2779,13 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2757,6 +2794,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4.0"
       }

--- a/express-backend/prisma/migrations/20241217162010_/migration.sql
+++ b/express-backend/prisma/migrations/20241217162010_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `provider` to the `ActionTemplate` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "ActionTemplate" ADD COLUMN     "provider" TEXT NOT NULL;

--- a/express-backend/prisma/schema.prisma
+++ b/express-backend/prisma/schema.prisma
@@ -46,6 +46,7 @@ model ActionTemplate {
   name           String
   actFunc        String
   valueTemplate  Json
+  provider       String
   actions        Action[]
 }
 

--- a/express-backend/routes/action.ts
+++ b/express-backend/routes/action.ts
@@ -30,4 +30,22 @@ router.get('/templates', async (req: Request, res: Response) : Promise<any> => {
     }
 });
 
+router.get('/templates/:provider', async (req: Request, res: Response) : Promise<any> => {
+    const { provider } = req.params;
+    if (!provider) {
+        res.status(400).json({ error: 'Provider is required.' });
+        return;
+    }
+    try {
+        const templates = await prisma.actionTemplate.findMany({
+            where: {
+                provider: provider
+            }
+        });
+        res.status(200).json(templates);
+    } catch (error) {
+        res.status(500).json({ error: 'Failed to fetch action templates.' });
+    }
+});
+
 export default router;

--- a/express-backend/routes/trigger.ts
+++ b/express-backend/routes/trigger.ts
@@ -30,4 +30,22 @@ router.get('/templates', async (req: Request, res: Response) => {
     }
 });
 
+router.get('/templates/:provider', async (req: Request, res: Response) : Promise<any> => {
+    const { provider } = req.params;
+    if (!provider) {
+        res.status(400).json({ error: 'Provider is required.' });
+        return;
+    }
+    try {
+        const templates = await prisma.triggerTemplate.findMany({
+            where: {
+                provider: provider
+            }
+        });
+        res.status(200).json(templates);
+    } catch (error) {
+        res.status(500).json({ error: 'Failed to fetch trigger templates.' });
+    }
+});
+
 export default router;

--- a/express-backend/scripts/createActionTemplate.ts
+++ b/express-backend/scripts/createActionTemplate.ts
@@ -8,6 +8,7 @@ async function createActionTemplate() {
       data: {
         name: 'Send Discord Message',
         actFunc: 'sendDiscordMessage',
+        provider: 'Discord',
         valueTemplate: {
           webhookUrl: 'https://discord.com/api/webhooks/YOUR_WEBHOOK_URL',
           content: 'Test message',


### PR DESCRIPTION
Feature /triggers/templates/:provider &  /actions/templates/:provider --- backend


This pull request includes several changes to the `express-backend/package-lock.json` file, primarily focusing on marking dependencies as development dependencies. The most important changes include the addition of the `"dev": true` flag to various dependencies.

Changes to dependencies:

* Marked `@types/node` as a development dependency.
* Marked `accepts`, `array-flatten`, `body-parser`, and `bytes` as development dependencies. [[1]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1057) [[2]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dL1104-R1106) [[3]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1155) [[4]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1196)
* Marked `content-disposition`, `content-type`, `cookie`, and `cookie-signature` as development dependencies. [[1]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1295) [[2]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1307) [[3]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1316-R1325)
* Marked `debug`, `depd`, `destroy`, and `ee-first` as development dependencies. [[1]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1364) [[2]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1406) [[3]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1415) [[4]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dL1465-R1483)
* Marked `encodeurl`, `escape-html`, `etag`, and `express` as development dependencies. [[1]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dL1539-R1553) [[2]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1576) [[3]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1593)
* Marked `finalhandler`, `forwarded`, `fresh`, and `http-errors` as development dependencies. [[1]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1641) [[2]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1706) [[3]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1715) [[4]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1860)
* Marked `iconv-lite`, `ipaddr.js`, `media-typer`, and `merge-descriptors` as development dependencies. [[1]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1876) [[2]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR1904) [[3]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR2062) [[4]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR2071)
* Marked `mime`, `ms`, `negotiator`, and `on-finished` as development dependencies. [[1]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR2088) [[2]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dL2105-R2131) [[3]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR2154) [[4]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR2182)
* Removed `openapi-types` as a dependency.
* Marked `parseurl`, `path-to-regexp`, `proxy-addr`, and `range-parser` as development dependencies. [[1]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dL2197-R2220) [[2]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR2291) [[3]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR2324)
* Marked `raw-body`, `safe-buffer`, and `safer-buffer` as development dependencies. [[1]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR2333) [[2]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dR2385) [[3]](diffhunk://#diff-b753ef08965d4c61007ad23ad249d8932acd4cc9262c859192afdd07f8ff1b5dL2377-R2405)