### PR TITLE
FEAT: Add a names in db for plums

### DIFF
--- a/express-backend/cron/SpotifyCron.ts
+++ b/express-backend/cron/SpotifyCron.ts
@@ -3,7 +3,7 @@ import CryptoJS from 'crypto-js';
 
 
 function decryptToken(encryptedToken: string): string {
-    const secret = process.env.SECRET
+    const secret = process.env.SPOTIFY_SECRET
 
     if (!secret)
         throw new Error('SECRET environment variable is not defined');

--- a/express-backend/prisma/migrations/20241218164956_add_plum_name/migration.sql
+++ b/express-backend/prisma/migrations/20241218164956_add_plum_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `name` to the `Plum` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Plum" ADD COLUMN     "name" TEXT NOT NULL;

--- a/express-backend/prisma/schema.prisma
+++ b/express-backend/prisma/schema.prisma
@@ -35,6 +35,7 @@ model Token {
 
 model Plum {
   id         Int      @id @default(autoincrement())
+  name       String
   user       User     @relation(fields: [userId], references: [userId])
   userId     Int
   action     Action   @relation(fields: [actionId], references: [id])

--- a/express-backend/routes/plums.ts
+++ b/express-backend/routes/plums.ts
@@ -39,7 +39,8 @@ const router = express.Router();
  *         description: Internal server error
  */
 router.post('/', authenticateToken, async (req: Request, res: Response) : Promise<any> => {
-  const {   actionTemplateId,
+  const {   name,
+            actionTemplateId,
             actionValue,
             triggerTemplateId,
             triggerValue
@@ -79,6 +80,7 @@ router.post('/', authenticateToken, async (req: Request, res: Response) : Promis
 
     const plum = await prisma.plum.create({
       data: {
+        name: name,
         userId,
         actionId: action.id,
         triggerId: trigger.id,

--- a/express-backend/routes/spotify.ts
+++ b/express-backend/routes/spotify.ts
@@ -29,7 +29,7 @@ const SPOTIFY_REDIRECT_URI = `http://localhost:${process.env.PORT}/spotify/callb
 
 
 function encryptToken(token: string): string {
-  const secret = process.env.SECRET
+  const secret = process.env.SPOTIFY_SECRET
 
   if (!secret)
     throw new Error('SECRET environment variable is not defined');


### PR DESCRIPTION
I've just added a name in databases for the plums table.

And I've also fixed the usage of only one secret for encryption token in spotify service