### PR TITLE
FEAT: Create CSS Explore page (FNW-22)

### DIFF
--- a/react-frontend/src/components/Explore/ExploreContent.tsx
+++ b/react-frontend/src/components/Explore/ExploreContent.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+interface IService {
+    name: string;
+    logo: string;
+}
+
+export default function ExploreContent() {
+
+    const [services, setServices] = useState<IService[]>([
+        {
+            name: "Discord",
+            logo: "https://logo-marque.com/wp-content/uploads/2020/12/Discord-Logo.png"
+        }
+    ]);
+
+    return (
+        <div className="mx-6 sm:mx-10 md:mx-20 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-11">
+            {services.map((service, index) => (
+                <button
+                key={index}
+                className="flex flex-col items-center justify-center p-6 bg-white h-72 w-full max-w-sm font-instrumentSans border border-gray-200 rounded-lg shadow-custom hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700"
+                >
+                <img
+                    src={service.logo}
+                    alt={service.name}
+                    className="w-24 h-24 rounded-full object-contain mb-4"
+                />
+                <h5 className="text-2xl font-bold text-customDarkGreen tracking-tight dark:text-white text-center">
+                    {service.name}
+                </h5>
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/react-frontend/src/components/Explore/ExploreNavbar.tsx
+++ b/react-frontend/src/components/Explore/ExploreNavbar.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+export default function ExploreNavbar() {
+  const [activeButton, setActiveButton] = useState('All');
+
+  const handleButtonClick = (buttonName : string) => {
+    setActiveButton(buttonName);
+  };
+
+return (
+    <div className="flex flex-col items-center py-8 mt-24 mx-2">
+      <h1 className="text-4xl font-abrilFatface text-customGreen mb-6">Explore</h1>
+      <div className="flex space-x-4 mb-4">
+        <button
+          className={`text-customGreen font-medium pb-1 ${
+            activeButton === 'All' ? 'border-b-2 border-customGreen' : ''
+          }`}
+          onClick={() => handleButtonClick('All')}
+        >
+          All
+        </button>
+        <button
+          className={`text-customGreen font-medium pb-1 ${
+            activeButton === 'Plums' ? 'border-b-2 border-customGreen' : ''
+          }`}
+          onClick={() => handleButtonClick('Plums')}
+        >
+          Plums
+        </button>
+        <button
+          className={`text-customGreen font-medium pb-1 ${
+            activeButton === 'Services' ? 'border-b-2 border-customGreen' : ''
+          }`}
+          onClick={() => handleButtonClick('Services')}
+        >
+          Services
+        </button>
+      </div>
+      <input
+        type="search"
+        placeholder="Search Plums or services"
+        className="border border-gray-300 rounded-lg px-4 py-2 w-full max-w-md text-gray-700 focus:outline-none focus:ring-2 focus:ring-customGreen"
+      />
+    </div>
+  );
+}

--- a/react-frontend/src/pages/Explore/explore.tsx
+++ b/react-frontend/src/pages/Explore/explore.tsx
@@ -1,3 +1,5 @@
+import ExploreContent from "../../components/Explore/ExploreContent";
+import ExploreNavbar from "../../components/Explore/ExploreNavbar";
 import Navbar from "../../components/Navbar/navbar";
 
 interface IService {
@@ -43,11 +45,8 @@ export default function Explore () {
     return (
         <div>
             <Navbar></Navbar>
-            <h1>Explore</h1>
-            <button>All</button>
-            <button>Plums</button>
-            <button>Services</button>
-            <input type="search" placeholder="Search Plums or services"></input>
+            <ExploreNavbar />
+            <ExploreContent />
             {
                 ServiceCards.map((card, index) => (
                     <ServiceCard key={index} {...card} />


### PR DESCRIPTION
This pull request introduces new components and refactors the existing `Explore` page in the `react-frontend` project. The changes include the creation of `ExploreContent` and `ExploreNavbar` components and the integration of these components into the `Explore` page.

New Components:

* [`react-frontend/src/components/Explore/ExploreContent.tsx`](diffhunk://#diff-15c7b0fa309213cb1c013278c671b91d7619e19e192df2908714d30e6a1b9f6cR1-R36): Created `ExploreContent` component to display a grid of services with their logos and names.
* [`react-frontend/src/components/Explore/ExploreNavbar.tsx`](diffhunk://#diff-9fedb0c35631491aad216c720141fc76af0cbf412e61abfae20b5f729e55ad3aR1-R46): Created `ExploreNavbar` component with buttons to filter content and a search input.

Refactoring:

* [`react-frontend/src/pages/Explore/explore.tsx`](diffhunk://#diff-53964cedca8b480f15ba6259bf01ddc201fbc55ce34242555ba320fb0879fad0R1-R2): Refactored the `Explore` page to use the new `ExploreNavbar` and `ExploreContent` components, replacing the previous static content. [[1]](diffhunk://#diff-53964cedca8b480f15ba6259bf01ddc201fbc55ce34242555ba320fb0879fad0R1-R2) [[2]](diffhunk://#diff-53964cedca8b480f15ba6259bf01ddc201fbc55ce34242555ba320fb0879fad0L46-R49)

Here a preview of the render page:
![image](https://github.com/user-attachments/assets/df5cf9de-6e69-44a9-9188-9a1a095eadcc)
