### PR TITLE
fix(updateCron): Add a condition to verify if the table trigger exist or not

### DIFF
--- a/express-backend/cron/UpdateCron.ts
+++ b/express-backend/cron/UpdateCron.ts
@@ -29,6 +29,11 @@ const actionsMapFunction: Map<string, (userId: number, value_json: string) => Pr
 
 async function updateCron() {
     try {
+        const tableExists : any = await prisma.$queryRaw`SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'Trigger')`;
+        if (!tableExists[0].exists) {
+            console.log('Trigger table does not exist.');
+            return;
+        }
         const triggers = await prisma.trigger.findMany();
         for (const trigger of triggers) {
             if (cronMap.has(trigger.id))


### PR DESCRIPTION
This pull request includes a change to the `express-backend/cron/UpdateCron.ts` file to add a check for the existence of the 'Trigger' table before proceeding with the update process.

* [`express-backend/cron/UpdateCron.ts`](diffhunk://#diff-2664c37983c6d03fb86e0947fa5218ab4edf756e3bbd6f36eb482699e51e3c0bR32-R36): Added a query to check if the 'Trigger' table exists in the database and log a message if it does not, preventing further execution if the table is missing.