### PR TITLE
FEAT: Link back to myPlums page (FNW-29/FNW-26)

### DIFF
--- a/react-frontend/src/pages/MyPlums/myPlums.tsx
+++ b/react-frontend/src/pages/MyPlums/myPlums.tsx
@@ -4,31 +4,68 @@ import feather from '../../assets/myPlums/feather.svg';
 import filter from '../../assets/myPlums/filter.svg';
 import { useNavigate } from "react-router-dom";
 import Filter from "../../components/Filter/Filter";
+import { getPlums } from "../../services/Plums/plums";
+
+interface Template {
+    provider: string;
+}
+
+interface TriggerPlum {
+    name: string;
+    triggerTemplate: Template;
+}
+
+interface ActionPlum {
+    name: string;
+    actionTemplate: Template;
+}
 
 export interface Plum {
     name: string;
-    services: string;
+    provider: string;
     isActivated: boolean;
+    trigger: TriggerPlum;
+    action: ActionPlum;
 }
 
 export default function MyPlums() {
     const navigate = useNavigate();
 
-    const [originalPlums] = useState<Plum[]>([
-        { name: 'Plum 1', services: 'Service 1, Service 2', isActivated: true },
-        { name: 'Plum 2', services: 'Service 2, Service 4, Service 3', isActivated: true },
-        { name: 'Plum 3', services: 'Service 3, Service 4, Service 2', isActivated: false },
-        { name: 'Plum 4', services: 'Service 4, Service 3', isActivated: false },
-        { name: 'Plum 5', services: 'Service 4, Service 2', isActivated: true },
-    ]);
+    const [originalPlums, setOriginalPlums] = useState<Plum[]>([]);
 
-    const [services] = useState<string[]>(["Service 1", "Service 2", "Service 3", "Service 4"]);
-    const [myPlums, setMyPlums] = useState<Plum[]>(originalPlums);
+    const [provider] = useState<string[]>([]);
+    const [myPlums, setMyPlums] = useState<Plum[]>([]);
 
     const [searchInput, setSearchInput] = useState('');
     const [currentStatusFilter, setCurrentStatusFilter] = useState<'All' | 'On' | 'Off'>('All');
     const [selectedServices, setSelectedServices] = useState<string[]>([]);
     const [filterOpen, setFilterOpen] = useState(false);
+
+    useEffect(() => {
+        const fetchPlums = async () => {
+            try {
+                const plums = await getPlums();
+                if (plums) {
+
+                    plums.forEach((plum: Plum) => {
+                        plum.provider = plum.trigger.triggerTemplate.provider + ', ' + plum.action.actionTemplate.provider;
+                        if (!provider.includes(plum.trigger.triggerTemplate.provider)) {
+                            provider.push(plum.trigger.triggerTemplate.provider);
+                        }
+                        if (!provider.includes(plum.action.actionTemplate.provider)) {
+                            provider.push(plum.action.actionTemplate.provider);
+                        }
+                    });
+
+                    setOriginalPlums(plums);
+                    setMyPlums(plums);
+                }
+            } catch (error) {
+                console.error("Error fetching plums:", error);
+            }
+        };
+        fetchPlums();
+    }, []);
 
     const applyFilters = () => {
         let filtered = [...originalPlums];
@@ -44,7 +81,7 @@ export default function MyPlums() {
 
         if (selectedServices.length > 0) {
             filtered = filtered.filter((plum) =>
-                selectedServices.some((service) => plum.services.split(', ').includes(service))
+                selectedServices.some((service) => plum.provider.split(', ').includes(service))
             );
         }
 
@@ -63,8 +100,8 @@ export default function MyPlums() {
         setCurrentStatusFilter(filterType);
     };
 
-    const filterByServices = (services: string[]) => {
-        setSelectedServices(services);
+    const filterByServices = (provider: string[]) => {
+        setSelectedServices(provider);
     };
 
     return (
@@ -113,7 +150,7 @@ export default function MyPlums() {
                         Create
                     </button>
                 </div>
-                {filterOpen && <Filter myPlums={myPlums} filterPlums={filterPlums} services={services} filterByServices={filterByServices}/>}
+                {filterOpen && <Filter myPlums={myPlums} filterPlums={filterPlums} services={provider} filterByServices={filterByServices}/>}
                 <div className="flex justify-center">
                     <div className="relative overflow-x-auto w-full">
                         <table className="w-full text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400">
@@ -150,7 +187,7 @@ export default function MyPlums() {
                                                 {plum.name}
                                             </div>
                                         </th>
-                                        <td className="px-6 py-4">{plum.services}</td>
+                                        <td className="px-6 py-4">{plum.provider}</td>
                                         <td className="px-6 py-4">
                                             <button
                                                 className={`relative w-14 h-8 flex items-center rounded-full p-1 ${

--- a/react-frontend/src/services/Plums/plums.tsx
+++ b/react-frontend/src/services/Plums/plums.tsx
@@ -56,6 +56,19 @@ export const createPlum = async (name : string, trigger : Trigger, action : Acti
     }
 };
 
+export const getPlums = async () => {
+    try {
+        const token = localStorage.getItem("access_token");
+        const headers = {
+            Authorization: `Bearer ${token}`
+        };
+        const response = await axios.get(`${process.env.REACT_APP_API_URL}/plums`, { headers: headers });
+        return response.data;
+    } catch (error) {
+        return [];
+    }
+};
+
 export const getProvidersTriggers = async (provider : string): Promise<Trigger[]> => {
     try {
         const response = await axios.get(`${process.env.REACT_APP_API_URL}/triggers/templates/${provider}`);


### PR DESCRIPTION
This pull request includes several changes to the `MyPlums` page in the `react-frontend` project, focusing on refactoring the code to use providers instead of services and adding a new function to fetch plums from an API. The most important changes include the introduction of new interfaces for plums, updating state management, and modifying filtering logic.

### Refactoring to use providers:

* [`react-frontend/src/pages/MyPlums/myPlums.tsx`](diffhunk://#diff-044c6831d646085bcc875f08e781537417be60937eced8abdabc3d8c816e5bb5R7-R69): Replaced the `services` attribute in the `Plum` interface with `provider`, and updated the component state and filtering logic to use providers instead of services. [[1]](diffhunk://#diff-044c6831d646085bcc875f08e781537417be60937eced8abdabc3d8c816e5bb5R7-R69) [[2]](diffhunk://#diff-044c6831d646085bcc875f08e781537417be60937eced8abdabc3d8c816e5bb5L47-R84) [[3]](diffhunk://#diff-044c6831d646085bcc875f08e781537417be60937eced8abdabc3d8c816e5bb5L66-R104) [[4]](diffhunk://#diff-044c6831d646085bcc875f08e781537417be60937eced8abdabc3d8c816e5bb5L116-R153) [[5]](diffhunk://#diff-044c6831d646085bcc875f08e781537417be60937eced8abdabc3d8c816e5bb5L153-R190)

### Adding API call to fetch plums:

* [`react-frontend/src/services/Plums/plums.tsx`](diffhunk://#diff-688a71ea4fcab1db6d423126137232124aa573e943102809e05c28ccd089aa78R59-R71): Added a new function `getPlums` to fetch plums from an API and handle errors gracefully.
* [`react-frontend/src/pages/MyPlums/myPlums.tsx`](diffhunk://#diff-044c6831d646085bcc875f08e781537417be60937eced8abdabc3d8c816e5bb5R7-R69): Integrated the `getPlums` function into the `MyPlums` component to fetch and set the plums data on component mount.

Here a preview :
![image](https://github.com/user-attachments/assets/9ea33a33-1560-45fd-9fbc-c0504f3975de)
