### PR TITLE
FEAT: Added connection route in template

### DIFF
--- a/express-backend/scripts/createActionTemplate.ts
+++ b/express-backend/scripts/createActionTemplate.ts
@@ -36,6 +36,10 @@ async function stopPlayingSpotifyMusicTemplate() {
         actFunc: 'stopPlayingSpotifyMusic',
         provider: 'Spotify',
         valueTemplate: {
+          signup: {
+            value: "/spotify/authentification",
+            type: "signup",
+          }
         },
       },
     });
@@ -56,6 +60,10 @@ async function resumePlayingSpotifyMusicTemplate() {
         actFunc: 'resumePlayingSpotifyMusic',
         provider: 'Spotify',
         valueTemplate: {
+          signup: {
+            value: "/spotify/authentification",
+            type: "signup",
+          }
         },
       },
     });
@@ -76,6 +84,10 @@ async function skipNextSpotifyMusicTemplate() {
         actFunc: 'skipToNextTrackSpotify',
         provider: 'Spotify',
         valueTemplate: {
+          signup: {
+            value: "/spotify/authentification",
+            type: "signup",
+          }
         },
       },
     });
@@ -96,6 +108,10 @@ async function skipPreviousSpotifyMusicTemplate() {
         actFunc: 'previousPlayingSpotifyMusic',
         provider: 'Spotify',
         valueTemplate: {
+          signup: {
+            value: "/spotify/authentification",
+            type: "signup",
+          }
         },
       },
     });

--- a/express-backend/scripts/createTriggerTemplate.ts
+++ b/express-backend/scripts/createTriggerTemplate.ts
@@ -303,10 +303,14 @@ async function isSpotifyNewLikeTriggerTemplate() {
           type: 'cron',
           trigFunc: 'spotifyNewLike',
           valueTemplate: {
-              time: {
-                  value: '* * * * *',
-                  type: 'CRON expression',
-              }
+                time: {
+                    value: '* * * * *',
+                    type: 'CRON expression',
+                },
+                signup: {
+                    value: "/spotify/authentification",
+                    type: "signup",
+                }
           },
       },
       });
@@ -328,10 +332,14 @@ async function isSpotifyMusicPlayingTriggerTemplate() {
           type: 'cron',
           trigFunc: 'isSpotifyMusicPlaying',
           valueTemplate: {
-              time: {
-                  value: '* * * * *',
-                  type: 'CRON expression',
-              }
+                time: {
+                    value: '* * * * *',
+                    type: 'CRON expression',
+                },
+                signup: {
+                    value: "/spotify/authentification",
+                    type: "signup",
+                }
           },
       },
       });
@@ -356,6 +364,10 @@ async function isSpotifyMusicPausingTriggerTemplate() {
                 time: {
                     value: '* * * * *',
                     type: 'CRON expression',
+                },
+                signup: {
+                    value: "/spotify/authentification",
+                    type: "signup",
                 }
             },
         },


### PR DESCRIPTION
I've added the connection route in the action template and in the trigger templates of Spotify.

You gonna to tell me how you do this ?

So I've just add these line in agreement with Mathew:

signup: {
    value: "route/spotify/to/log",
    "type": "signup",
}