### PR TITLE
FEAT: Swagger json doc for lacking routes (FNW-137)

### DIFF
--- a/express-backend/routes/about.ts
+++ b/express-backend/routes/about.ts
@@ -4,7 +4,7 @@ import express, { Request, Response } from 'express';
 const router = express.Router();
 /**
  * @swagger
- * /about:
+ * /about.json:
  *   get:
  *     summary: Get server and client information
  *     responses:

--- a/express-backend/routes/about.ts
+++ b/express-backend/routes/about.ts
@@ -2,7 +2,55 @@ import prisma from '../prismaClient';
 import express, { Request, Response } from 'express';
 
 const router = express.Router();
-
+/**
+ * @swagger
+ * /about:
+ *   get:
+ *     summary: Get server and client information
+ *     responses:
+ *       200:
+ *         description: Successfully fetched server and client information
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 client:
+ *                   type: object
+ *                   properties:
+ *                     host:
+ *                       type: string
+ *                 server:
+ *                   type: object
+ *                   properties:
+ *                     current_time:
+ *                       type: integer
+ *                     services:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           name:
+ *                             type: string
+ *                           actions:
+ *                             type: array
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 name:
+ *                                   type: string
+ *                                 description:
+ *                                   type: string
+ *                           reactions:
+ *                             type: array
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 name:
+ *                                   type: string
+ *                                 description:
+ *                                   type: string
+ */
 router.get('/', async (req: Request, res: Response): Promise<any> => {
     try {
         const clientIp = req.ip;

--- a/express-backend/routes/action.ts
+++ b/express-backend/routes/action.ts
@@ -30,6 +30,33 @@ router.get('/templates', async (req: Request, res: Response) : Promise<any> => {
     }
 });
 
+/**
+ * @swagger
+ * /action/templates/{provider}:
+ *   get:
+ *     summary: Get all action templates for a specific provider
+ *     tags: [Templates]
+ *     parameters:
+ *       - in: path
+ *         name: provider
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The provider for which to fetch templates
+ *     responses:
+ *       200:
+ *         description: A list of action templates
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *       400:
+ *         description: Provider is required
+ *       500:
+ *         description: Failed to fetch action templates
+ */
 router.get('/templates/:provider', async (req: Request, res: Response) : Promise<any> => {
     const { provider } = req.params;
     if (!provider) {

--- a/express-backend/routes/plums.ts
+++ b/express-backend/routes/plums.ts
@@ -214,6 +214,48 @@ router.delete('/:plumId', authenticateToken, async (req: Request, res: Response)
     }
 });
 
+/**
+ * @swagger
+ * /plums/{plumId}:
+ *   put:
+ *     summary: Update a plum by ID
+ *     tags: [Plums]
+ *     parameters:
+ *       - in: path
+ *         name: plumId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: The ID of the plum to update
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               actionTemplateId:
+ *                 type: integer
+ *               actionValue:
+ *                 type: object
+ *                 additionalProperties:
+ *                   type: string
+ *               triggerTemplateId:
+ *                 type: integer
+ *               triggerValue:
+ *                 type: object
+ *                 additionalProperties:
+ *                   type: string
+ *     responses:
+ *       200:
+ *         description: Plum updated successfully
+ *       404:
+ *         description: Plum not found
+ *       500:
+ *         description: Internal server error
+ */
 router.put('/:plumId', authenticateToken, async (req: Request, res: Response) : Promise<any> => {
     let id = req.params.plumId;
     const {

--- a/express-backend/routes/services.ts
+++ b/express-backend/routes/services.ts
@@ -3,6 +3,24 @@ import express, {Request, Response} from 'express';
 
 const servicesRouter = express.Router();
 
+/**
+ * @swagger
+ * /services:
+ *   get:
+ *     summary: Get all services
+ *     tags: [Services]
+ *     responses:
+ *       200:
+ *         description: A list of services
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *       404:
+ *         description: No services found
+ */
 servicesRouter.get('/', async (req: Request, res: Response) => {
   const services = await prisma.service.findMany();
   if (!services) {

--- a/express-backend/routes/trigger.ts
+++ b/express-backend/routes/trigger.ts
@@ -30,6 +30,33 @@ router.get('/templates', async (req: Request, res: Response) => {
     }
 });
 
+/**
+ * @swagger
+ * /trigger/templates/{provider}:
+ *   get:
+ *     summary: Get all trigger templates for a provider
+ *     tags: [Trigger]
+ *     parameters:
+ *       - in: path
+ *         name: provider
+ *         required: true
+ *         description: Provider name
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: A list of trigger templates
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *       400:
+ *         description: Provider is required
+ *       500:
+ *         description: Failed to fetch trigger templates
+ */
 router.get('/templates/:provider', async (req: Request, res: Response) : Promise<any> => {
     const { provider } = req.params;
     if (!provider) {


### PR DESCRIPTION
This pull request adds Swagger documentation to several routes in the `express-backend` project. The documentation provides detailed information about the endpoints, including their parameters, request bodies, and responses.

Swagger documentation added to the following routes:

* [`express-backend/routes/about.ts`](diffhunk://#diff-9552e5a6a9731723b2b1294429b95e96e62905221584f1862d9029500eeb619fL5-R53): Added documentation for the `/about.json` endpoint to describe server and client information.
* [`express-backend/routes/action.ts`](diffhunk://#diff-524062e9eb1f314dc606d50d66293ee440e7d1d8b5a76dbc7989316de96f21d0R33-R59): Added documentation for the `/action/templates/{provider}` endpoint to describe fetching action templates for a specific provider.
* [`express-backend/routes/plums.ts`](diffhunk://#diff-d159aa94893c4d2ff54a59ffade2596f418e3d67f998efe36df8cd8ea848a232R217-R258): Added documentation for the `/plums/{plumId}` endpoint to describe updating a plum by ID.
* [`express-backend/routes/services.ts`](diffhunk://#diff-6b59d8c102449cbf21c79ed5663864322bd1c37d26b71da044c458ceceefb712R6-R23): Added documentation for the `/services` endpoint to describe fetching all services.
* [`express-backend/routes/trigger.ts`](diffhunk://#diff-402fc5b588dc88c3159a36ffbe838890d7356ca34593f41d006f7c57a57555e2R33-R59): Added documentation for the `/trigger/templates/{provider}` endpoint to describe fetching trigger templates for a provider.