### PR TITLE
FEAT: Create table samples plums

### DIFF
--- a/express-backend/index.ts
+++ b/express-backend/index.ts
@@ -12,6 +12,8 @@ import aboutRouter from './routes/about';
 import swaggerDocs from './docs/swagger';
 import servicesRouter from './routes/services';
 import initAllTemplates from './scripts/initTemplates';
+import samplePlumsRouter from "./routes/samplePlums";
+
 const swaggerUi = require("swagger-ui-express");
 
 dotenv.config();
@@ -32,6 +34,7 @@ app.use('/spotify', spotifyRouter);
 app.use('/account', accountRouter);
 app.use('/about.json', aboutRouter);
 app.use('/services', servicesRouter);
+app.use('/sampleplums', samplePlumsRouter);
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 

--- a/express-backend/prisma/migrations/20250116141619_/migration.sql
+++ b/express-backend/prisma/migrations/20250116141619_/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "SamplePlums" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "triggerValue" JSONB NOT NULL,
+    "triggerTemplateId" INTEGER NOT NULL,
+    "actionValue" JSONB NOT NULL,
+    "actionTemplateId" INTEGER NOT NULL,
+
+    CONSTRAINT "SamplePlums_pkey" PRIMARY KEY ("id")
+);

--- a/express-backend/prisma/migrations/20250116141922_/migration.sql
+++ b/express-backend/prisma/migrations/20250116141922_/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `actionTemplateId` on the `SamplePlums` table. All the data in the column will be lost.
+  - You are about to drop the column `triggerTemplateId` on the `SamplePlums` table. All the data in the column will be lost.
+  - Added the required column `actionTemplateName` to the `SamplePlums` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `actionTemplateProvider` to the `SamplePlums` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `triggerTemplateName` to the `SamplePlums` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `triggerTemplateProvider` to the `SamplePlums` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "SamplePlums" DROP COLUMN "actionTemplateId",
+DROP COLUMN "triggerTemplateId",
+ADD COLUMN     "actionTemplateName" TEXT NOT NULL,
+ADD COLUMN     "actionTemplateProvider" TEXT NOT NULL,
+ADD COLUMN     "triggerTemplateName" TEXT NOT NULL,
+ADD COLUMN     "triggerTemplateProvider" TEXT NOT NULL;

--- a/express-backend/prisma/schema.prisma
+++ b/express-backend/prisma/schema.prisma
@@ -20,7 +20,7 @@ model User {
   tokens         Token[]
   plums          Plum[]
   actions        Action[]
-  triggers        Trigger[]
+  triggers       Trigger[]
 }
 
 model Token {
@@ -40,7 +40,7 @@ model Plum {
   userId    Int
   action    Action  @relation(fields: [actionId], references: [id])
   actionId  Int
-    trigger   Trigger @relation(fields: [triggerId], references: [id])
+  trigger   Trigger @relation(fields: [triggerId], references: [id])
   triggerId Int
 }
 
@@ -88,9 +88,20 @@ model Trigger {
 }
 
 model Service {
-    name      String
-    description String
-    provider  String @unique
-    logo     String
-    color   String
+  name        String
+  description String
+  provider    String @unique
+  logo        String
+  color       String
+}
+
+model SamplePlums {
+  id                      Int    @id @default(autoincrement())
+  name                    String
+  triggerValue            Json
+  triggerTemplateName     String
+  triggerTemplateProvider String
+  actionValue             Json
+  actionTemplateName      String
+  actionTemplateProvider  String
 }

--- a/express-backend/routes/samplePlums.ts
+++ b/express-backend/routes/samplePlums.ts
@@ -1,0 +1,130 @@
+import prisma from '../prismaClient'
+import express, {Request, Response} from 'express';
+import authenticateToken from '../middlewares/isLoggedIn';
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * /sampleplums:
+ *   post:
+ *     summary: Create a new SamplePlum
+ *     tags: [SamplePlums]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               actionTemplateName:
+ *                 type: string
+ *               actionTemplateProvider:
+ *                 type: string
+ *               actionValue:
+ *                 type: object
+ *               triggerTemplateName:
+ *                 type: string
+ *               triggerTemplateProvider:
+ *                 type: string
+ *               triggerValue:
+ *                 type: object
+ *     responses:
+ *       200:
+ *         description: SamplePlum created successfully
+ *       400:
+ *         description: Missing required fields or Plum already exists
+ *       404:
+ *         description: ActionTemplate or TriggerTemplate not found
+ *       500:
+ *         description: Internal server error
+ */
+router.post('/', authenticateToken, async (req: Request, res: Response) : Promise<any> => {
+    const {
+        name,
+        actionTemplateName,
+        actionTemplateProvider,
+        actionValue,
+        triggerTemplateName,
+        triggerTemplateProvider,
+        triggerValue
+    } = req.body;
+
+    if (!name || !actionTemplateName || !actionTemplateProvider || !triggerTemplateName || !triggerTemplateProvider)
+        return res.status(400).json({error: 'Missing required fields'});
+    try {
+        const isSamplePlum = await prisma.plum.findFirst({
+            where: {
+                name: name
+            }
+        });
+
+        if (isSamplePlum)
+            return res.status(400).json({error: 'Plum already exists'});
+
+        const actionTemplate = await prisma.actionTemplate.findUnique({
+            where: {
+                name_provider: { name: actionTemplateName, provider: actionTemplateProvider },
+            }
+        });
+        if (!actionTemplate)
+            return res.status(404).json({error: 'ActionTemplate not found'});
+
+        const triggerTemplate = await prisma.triggerTemplate.findUnique({
+            where: {
+                name_provider: { name: triggerTemplateName, provider: triggerTemplateProvider },
+            }
+        });
+        if (!triggerTemplate)
+            return res.status(404).json({error: 'TriggerTemplate not found'});
+
+        await prisma.samplePlums.create({
+            data: {
+                name: name,
+                triggerTemplateName: triggerTemplateName,
+                triggerTemplateProvider: triggerTemplateProvider,
+                triggerValue: triggerValue || triggerTemplate.valueTemplate,
+                actionTemplateName: actionTemplateName,
+                actionTemplateProvider: actionTemplateProvider,
+                actionValue: actionValue || actionTemplate.valueTemplate,
+            }
+        });
+        return res.status(200).json({message: 'SamplePlum created successfully'});
+    } catch (error) {
+        console.error('Error creating SamplePlum:', error);
+        return res.status(500).json({error: 'Internal server error'});
+    }
+});
+
+/**
+ * @swagger
+ * /sampleplums:
+ *   get:
+ *     summary: Get all SamplePlums
+ *     tags: [SamplePlums]
+ *     responses:
+ *       200:
+ *         description: A list of SamplePlums
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *       500:
+ *         description: Internal server error
+ */
+router.get('/', authenticateToken, async (req: Request, res: Response) : Promise<any> => {
+    try {
+        const samplePlums = await prisma.samplePlums.findMany();
+
+        return res.status(200).json({samplePlums: samplePlums});
+    } catch (error) {
+        console.error('Error getting SamplePlums:', error);
+        return res.status(500).json({error: 'Internal server error'});
+    }
+});
+
+export default router;


### PR DESCRIPTION
This pull request introduces a new feature to manage "SamplePlums" in the application. The changes include adding a new route, creating a new database table, and implementing the necessary API endpoints to handle CRUD operations for SamplePlums.

### New Feature: SamplePlums Management

* **Route and Middleware Integration:**
  * Added `samplePlumsRouter` to the Express application and configured it to handle requests at the `/sampleplums` endpoint. [[1]](diffhunk://#diff-28814191dab642f6bca2b5164f4bd6f86993f45a6f87400dbb27223f4eac4f98R15-R16) [[2]](diffhunk://#diff-28814191dab642f6bca2b5164f4bd6f86993f45a6f87400dbb27223f4eac4f98R37)

* **Database Schema:**
  * Created a new `SamplePlums` table with columns for `id`, `name`, `triggerValue`, `triggerTemplateName`, `triggerTemplateProvider`, `actionValue`, `actionTemplateName`, and `actionTemplateProvider`. [[1]](diffhunk://#diff-798f1c29bf2d98af3a9c18915cb1869f3a951f692095d2595f1da8ec4be7b944R1-R11) [[2]](diffhunk://#diff-558eddc22a366fce62750ccb8f654524c0a2fc41ae8d967512840b2d7333d221R97-R107)
  * Updated the `SamplePlums` table schema to replace `triggerTemplateId` and `actionTemplateId` with `triggerTemplateName`, `triggerTemplateProvider`, `actionTemplateName`, and `actionTemplateProvider`.

* **API Endpoints:**
  * Implemented POST `/sampleplums` endpoint to create a new SamplePlum, including validation and error handling for missing fields and existing records.
  * Implemented GET `/sampleplums` endpoint to retrieve all SamplePlums, with error handling for potential database issues.